### PR TITLE
Fix #21: Datas ficam em branco ao editar reserva

### DIFF
--- a/dainf-lab-client/src/app/pages/reservation/reservation.component.html
+++ b/dainf-lab-client/src/app/pages/reservation/reservation.component.html
@@ -6,6 +6,7 @@
   [form]="form"
   [formTemplate]="crudForm"
   [actionsTemplate]="customActions"
+  (entityLoad)="onEntityLoad($event)"
 ></app-crud>
 
 <ng-template #crudForm>

--- a/dainf-lab-client/src/app/pages/reservation/reservation.component.ts
+++ b/dainf-lab-client/src/app/pages/reservation/reservation.component.ts
@@ -113,6 +113,13 @@ export class ReservationComponent implements OnInit {
     }
   }
 
+  onEntityLoad(reservation: Reservation) {
+    this.form.patchValue({
+      reservationDate: reservation.reservationDate ? new Date(reservation.reservationDate) : null,
+      withdrawalDate: reservation.withdrawalDate ? new Date(reservation.withdrawalDate) : null,
+    });
+  }
+
   createLoanFromReservation(reservation: Reservation) {
     const loanItems = reservation.items.map((item) => ({
       item: item.item,


### PR DESCRIPTION
## Summary

Closes #21

## Changes

- fix: convert date strings to Date objects when editing a reservation (#21)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)