### PR TITLE
Fix #16: Email de confirmação não enviado ao criar usuário

### DIFF
--- a/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/controller/UserController.java
+++ b/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/controller/UserController.java
@@ -8,7 +8,9 @@ import br.edu.utfpr.dainf.search.request.SearchRequest;
 import br.edu.utfpr.dainf.service.UserService;
 import br.edu.utfpr.dainf.shared.CrudController;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.Valid;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +21,14 @@ public class UserController extends CrudController<Long, User, UserDTO, UserRepo
 
     public UserController() {
         super(User.class, UserDTO.class);
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<Long> create(@RequestBody @Valid UserDTO dto) {
+        User entity = toEntity(dto);
+        User saved = service.register(entity);
+        return new ResponseEntity<>(saved.getId(), HttpStatus.CREATED);
     }
 
     @Override

--- a/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/service/UserService.java
+++ b/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/service/UserService.java
@@ -63,7 +63,7 @@ public class UserService extends CrudService<Long, User, UserRepository> impleme
         return repository.save(user);
     }
 
-    public void register(User user) {
+    public User register(User user) {
         user.setEnabled(false);
         user.setEmailVerificado(false);
         user.setEmailVerificationToken(UUID.randomUUID().toString());
@@ -81,6 +81,8 @@ public class UserService extends CrudService<Long, User, UserRepository> impleme
                 .to(List.of(saved.getEmail()))
                 .content(mailContent)
                 .build());
+
+        return saved;
     }
 
     public void confirmEmail(String token) {


### PR DESCRIPTION
## Summary

Closes #16

## Changes

- fix: send confirmation email when admin creates user via /users endpoint (#16)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)