### PR TITLE
Fix #14: Cadastro de empréstimo não lista usuários (erro 403)

### DIFF
--- a/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/controller/UserController.java
+++ b/dainf-lab-server/src/main/java/br/edu/utfpr/dainf/controller/UserController.java
@@ -8,6 +8,7 @@ import br.edu.utfpr.dainf.search.request.SearchRequest;
 import br.edu.utfpr.dainf.service.UserService;
 import br.edu.utfpr.dainf.shared.CrudController;
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.validation.Valid;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +32,7 @@ public class UserController extends CrudController<Long, User, UserDTO, UserRepo
     @Override
     @PostMapping("/search")
     @RolesAllowed({UserRole.ADMIN, UserRole.LAB_TECHNICIAN})
-    public ResponseEntity<PagedModel<UserDTO>> search(SearchRequest request) {
+    public ResponseEntity<PagedModel<UserDTO>> search(@RequestBody @Valid SearchRequest request) {
         return super.search(request);
     }
 

--- a/dainf-lab-server/src/test/java/br/edu/utfpr/dainf/controller/UserControllerTest.java
+++ b/dainf-lab-server/src/test/java/br/edu/utfpr/dainf/controller/UserControllerTest.java
@@ -1,8 +1,11 @@
 package br.edu.utfpr.dainf.controller;
 
 import br.edu.utfpr.dainf.dto.UserDTO;
+import br.edu.utfpr.dainf.search.request.SearchRequest;
 import br.edu.utfpr.dainf.shared.CrudControllerTest;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class UserControllerTest extends CrudControllerTest<UserDTO> {
@@ -52,5 +55,18 @@ class UserControllerTest extends CrudControllerTest<UserDTO> {
         dto.setPassword(null);
 
         performUpdate(createdId, dto).andExpect(status().isOk());
+    }
+
+    @Test
+    void labTechnicianCanSearchUsers() throws Exception {
+        RequestPostProcessor labTechAuth = SecurityMockMvcRequestPostProcessors.user("lab").roles("LAB_TECHNICIAN");
+        performSearch(createSearchRequest(), labTechAuth).andExpect(status().isOk());
+    }
+
+    private org.springframework.test.web.servlet.ResultActions performSearch(SearchRequest request, RequestPostProcessor auth) throws Exception {
+        return mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post(getURL() + "/search")
+                .with(auth)
+                .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                .content(asJson(request)));
     }
 }


### PR DESCRIPTION
## Summary

Closes #14

## Changes

- fix: allow laboratorista to list users when registering a loan (issue #14)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)